### PR TITLE
Replace binary icon assets with vector-only workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,9 @@ __marimo__/
 # Custom
 vnvtoolkit/
 .idea/
+
+# Generated icon artifacts
+resources/icons/*.png
+resources/icons/*.ico
+resources/icons/*.icns
+resources/resources_rc.py

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ python -m src.app
 
 ---
 
+## 🎨 Application Icon
+
+- The repository ships a vector-first icon at `resources/icons/vector_dataset_tool.svg` to avoid committing binary assets.
+- Generated PNG/ICO/ICNS files and the compiled Qt resource module are ignored by git; create them locally when needed:
+
+  ```bash
+  python tools/generate_icons.py --source docs/milestones/vector_dataset_tool.png
+  pyside6-rcc resources/resources.qrc -o resources/resources_rc.py
+  ```
+
+- At runtime the app loads the Qt resource module when available and otherwise falls back to the tracked SVG on disk.
+- Packaging commands should run the generator first, for example: `pyinstaller --name "VectorDatasetToolkit" --icon resources/icons/vector_dataset_tool.ico src/app.py`.
+- Optional Linux desktop entry installer: `tools/install_desktop_entry.sh` (expects the generated `vector_dataset_tool_256x256.png`).
+
+---
+
 ## 💡 Contributing
 
 Contributions, ideas, and feature requests are welcome.  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "PySide6>=6.5.0",
     "numpy>=1.24.0",
     "h5py>=3.9.0",
+    "Pillow>=10.4.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 PySide6>=6.5.0
 numpy>=1.24.0
 h5py>=3.9.0
+Pillow>=10.4.0

--- a/resources/icons/vector_dataset_tool.svg
+++ b/resources/icons/vector_dataset_tool.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img">
+  <title>Vector Dataset Toolkit</title>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1b9ad7" />
+      <stop offset="100%" stop-color="#084d8c" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#ffd166" />
+      <stop offset="100%" stop-color="#fca311" />
+    </linearGradient>
+  </defs>
+  <rect x="32" y="32" width="448" height="448" rx="72" fill="url(#bg)" />
+  <g stroke="#ffffff" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M132 348c32-80 80-120 144-144 22-8 44-12 72-12" />
+    <path d="M152 224c24 16 48 24 72 24 48 0 76-28 112-56" />
+    <circle cx="168" cy="356" r="22" fill="url(#accent)" stroke="none" />
+    <circle cx="260" cy="296" r="22" fill="url(#accent)" stroke="none" />
+    <circle cx="352" cy="192" r="22" fill="url(#accent)" stroke="none" />
+  </g>
+  <text x="256" y="416" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="700" fill="#ffffff">
+    V
+  </text>
+</svg>

--- a/resources/resources.qrc
+++ b/resources/resources.qrc
@@ -1,0 +1,5 @@
+<RCC>
+  <qresource prefix="/icons">
+    <file>icons/vector_dataset_tool.svg</file>
+  </qresource>
+</RCC>

--- a/resources/vector-dataset-tool.desktop
+++ b/resources/vector-dataset-tool.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Vector Dataset Tool
+Comment=Inspect and convert vector dataset files
+Exec=vdt
+Icon=vector_dataset_tool
+Terminal=false
+Type=Application
+Categories=Utility;Science;
+StartupWMClass=Vector Dataset Tool

--- a/src/app.py
+++ b/src/app.py
@@ -7,10 +7,41 @@ Usage:
 """
 
 import sys
+from pathlib import Path
 
+from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
 
 from .ui.main_window import MainWindow
+
+
+def _load_window_icon() -> QIcon:
+    """Load the application icon with graceful fallbacks.
+
+    The Qt resource module (``resources_rc``) is optional to avoid tracking
+    generated binary assets in the repository. When it is not available, the
+    icon is resolved from the on-disk SVG instead.
+    """
+
+    try:  # Prefer resources compiled by ``pyside6-rcc`` when present.
+        from resources import resources_rc  # type: ignore  # noqa: F401
+    except Exception:
+        resources_rc = None
+
+    for candidate in (":/icons/vector_dataset_tool.png", ":/icons/vector_dataset_tool.svg"):
+        icon = QIcon(candidate)
+        if not icon.isNull():
+            return icon
+
+    icons_dir = Path(__file__).resolve().parent.parent / "resources" / "icons"
+    for filename in ("vector_dataset_tool.png", "vector_dataset_tool.svg"):
+        file_path = icons_dir / filename
+        if file_path.exists():
+            icon = QIcon(str(file_path))
+            if not icon.isNull():
+                return icon
+
+    return QIcon()
 
 
 def main() -> int:
@@ -22,6 +53,7 @@ def main() -> int:
     app = QApplication(sys.argv)
     app.setApplicationName("Vector Dataset Tool")
     app.setOrganizationName("VectorDatasetToolkit")
+    app.setWindowIcon(_load_window_icon())
     
     # Create and show main window
     window = MainWindow()

--- a/src/app.py
+++ b/src/app.py
@@ -28,10 +28,11 @@ def _load_window_icon() -> QIcon:
     except Exception:
         resources_rc = None
 
-    for candidate in (":/icons/vector_dataset_tool.png", ":/icons/vector_dataset_tool.svg"):
-        icon = QIcon(candidate)
-        if not icon.isNull():
-            return icon
+    if resources_rc:
+        for candidate in (":/icons/vector_dataset_tool.png", ":/icons/vector_dataset_tool.svg"):
+            icon = QIcon(candidate)
+            if not icon.isNull():
+                return icon
 
     icons_dir = Path(__file__).resolve().parent.parent / "resources" / "icons"
     for filename in ("vector_dataset_tool.png", "vector_dataset_tool.svg"):

--- a/tools/generate_icons.py
+++ b/tools/generate_icons.py
@@ -1,0 +1,177 @@
+"""Generate application icon set for Vector Dataset Toolkit.
+
+This script downloads or loads the base PNG icon and produces PNG, ICO,
+ICNS, and SVG outputs in ``resources/icons``.
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+import textwrap
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+try:
+    from PIL import Image
+except ModuleNotFoundError as exc:  # pragma: no cover - handled at runtime
+    Image = None
+    PIL_IMPORT_ERROR = exc
+else:
+    PIL_IMPORT_ERROR = None
+
+ROOT = Path(__file__).resolve().parent.parent
+ICONS_DIR = ROOT / "resources" / "icons"
+DEFAULT_SOURCE_PATH = ROOT / "docs" / "milestones" / "vector_dataset_tool.png"
+DEFAULT_ICON_URL = (
+    "https://raw.githubusercontent.com/zeevbensender/vector-dataset-toolkit/main/"
+    "docs/milestones/vector_dataset_tool.png"
+)
+ICON_BASENAME = "vector_dataset_tool"
+SIZES = [16, 32, 48, 64, 128, 256, 512]
+SVG_TEMPLATE = textwrap.dedent(
+    """
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img">
+      <title>Vector Dataset Toolkit</title>
+      <defs>
+        <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0%" stop-color="#1b9ad7" />
+          <stop offset="100%" stop-color="#084d8c" />
+        </linearGradient>
+        <linearGradient id="accent" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0%" stop-color="#ffd166" />
+          <stop offset="100%" stop-color="#fca311" />
+        </linearGradient>
+      </defs>
+      <rect x="32" y="32" width="448" height="448" rx="72" fill="url(#bg)" />
+      <g stroke="#ffffff" stroke-width="18" stroke-linecap="round" stroke-linejoin="round" fill="none">
+        <path d="M132 348c32-80 80-120 144-144 22-8 44-12 72-12" />
+        <path d="M152 224c24 16 48 24 72 24 48 0 76-28 112-56" />
+        <circle cx="168" cy="356" r="22" fill="url(#accent)" stroke="none" />
+        <circle cx="260" cy="296" r="22" fill="url(#accent)" stroke="none" />
+        <circle cx="352" cy="192" r="22" fill="url(#accent)" stroke="none" />
+      </g>
+      <text x="256" y="416" text-anchor="middle" font-family="'Inter', 'Segoe UI', sans-serif" font-size="72" font-weight="700" fill="#ffffff">
+        V
+      </text>
+    </svg>
+    """
+).strip()
+
+
+def _load_image(source: Path | None, url: str) -> Image.Image:
+    if Image is None:  # pragma: no cover - utility guard
+        raise SystemExit(
+            "Pillow is required to generate icons. Install it with `pip install Pillow`"
+        ) from PIL_IMPORT_ERROR
+
+    if source is None and DEFAULT_SOURCE_PATH.exists():
+        source = DEFAULT_SOURCE_PATH
+
+    if source and source.exists():
+        return Image.open(source).convert("RGBA")
+
+    with urlopen(url) as response:  # noqa: S310 - trusted URL owned by project
+        data = response.read()
+    return Image.open(io.BytesIO(data)).convert("RGBA")
+
+
+def _ensure_dirs() -> None:
+    ICONS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _save_base_png(image: Image.Image) -> Path:
+    output_path = ICONS_DIR / f"{ICON_BASENAME}.png"
+    image.save(output_path)
+    return output_path
+
+
+def _generate_resized_images(image: Image.Image) -> dict[int, Image.Image]:
+    resized: dict[int, Image.Image] = {}
+    for size in SIZES:
+        resized[size] = image.resize((size, size), Image.Resampling.LANCZOS)
+    return resized
+
+
+def _save_png_variants(resized: dict[int, Image.Image]) -> list[Path]:
+    outputs: list[Path] = []
+    for size, icon in resized.items():
+        output_path = ICONS_DIR / f"{ICON_BASENAME}_{size}x{size}.png"
+        icon.save(output_path)
+        outputs.append(output_path)
+    return outputs
+
+
+def _save_ico(resized: dict[int, Image.Image]) -> Path:
+    output_path = ICONS_DIR / f"{ICON_BASENAME}.ico"
+    base_image = resized[max(resized)]
+    base_image.save(output_path, format="ICO", sizes=[(s, s) for s in SIZES])
+    return output_path
+
+
+def _save_icns(resized: dict[int, Image.Image]) -> Path:
+    output_path = ICONS_DIR / f"{ICON_BASENAME}.icns"
+    resized[max(resized)].save(output_path, format="ICNS", sizes=[(s, s) for s in SIZES])
+    return output_path
+
+
+def _save_svg_placeholder(resized: dict[int, Image.Image]) -> Path:
+    """Write a standalone SVG that mirrors the shipped icon design."""
+
+    output_path = ICONS_DIR / f"{ICON_BASENAME}.svg"
+    output_path.write_text(SVG_TEMPLATE + "\n", encoding="utf-8")
+    return output_path
+
+
+def generate_icons(source: Path | None, url: str, skip_svg: bool = False) -> None:
+    _ensure_dirs()
+
+    try:
+        source_image = _load_image(source, url)
+    except (URLError, OSError) as exc:  # pragma: no cover - utility error handling
+        message = f"Unable to load source image from {source or url}: {exc}"
+        raise SystemExit(message) from exc
+
+    resized = _generate_resized_images(source_image)
+    base_png = _save_base_png(resized[max(resized)])
+    png_variants = _save_png_variants(resized)
+    ico = _save_ico(resized)
+    icns = _save_icns(resized)
+    svg = _save_svg_placeholder(resized) if not skip_svg else None
+
+    print("Generated icon assets:")
+    for path in [base_png, *png_variants, ico, icns]:
+        print(f" - {path.relative_to(ROOT)}")
+    if svg:
+        print(f" - {svg.relative_to(ROOT)}")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate application icons")
+    parser.add_argument(
+        "--source",
+        type=Path,
+        help="Path to a local PNG to use instead of downloading the default icon.",
+    )
+    parser.add_argument(
+        "--url",
+        default=DEFAULT_ICON_URL,
+        help="URL for downloading the source icon (used when --source is not provided).",
+    )
+    parser.add_argument(
+        "--skip-svg",
+        action="store_true",
+        help="Skip creation of the SVG placeholder if not required.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    generate_icons(args.source, args.url, skip_svg=args.skip_svg)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/install_desktop_entry.sh
+++ b/tools/install_desktop_entry.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd -- "${SCRIPT_DIR}/.." && pwd)"
+
+ICON_SOURCE="${REPO_ROOT}/resources/icons/vector_dataset_tool_256x256.png"
+DESKTOP_FILE="${REPO_ROOT}/resources/vector-dataset-tool.desktop"
+
+APPLICATIONS_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/applications"
+ICON_TARGET_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/icons/hicolor/256x256/apps"
+DESKTOP_TARGET="${APPLICATIONS_DIR}/vector-dataset-tool.desktop"
+ICON_TARGET="${ICON_TARGET_DIR}/vector_dataset_tool.png"
+
+if [[ ! -f "${ICON_SOURCE}" ]]; then
+    echo "Icon not found at ${ICON_SOURCE}. Run tools/generate_icons.py first." >&2
+    exit 1
+fi
+
+install -Dm644 "${DESKTOP_FILE}" "${DESKTOP_TARGET}"
+install -Dm644 "${ICON_SOURCE}" "${ICON_TARGET}"
+
+echo "Installed desktop entry to ${DESKTOP_TARGET}"
+echo "Installed icon to ${ICON_TARGET}"
+
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "${APPLICATIONS_DIR}" || true
+fi


### PR DESCRIPTION
## Summary
- remove generated binary icon artifacts from the repository and keep a vector SVG icon tracked
- update the icon loader and generation script to work without committed binaries while still supporting local PNG/ICO/ICNS outputs
- document the binary-free workflow and ignore regenerated assets in version control

## Testing
- python -m compileall src tools


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ffce8ab50832fb8d48a8279ede119)